### PR TITLE
Add README and GitHub Action for building and releasing exe

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,47 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build project
+      run: dotnet publish -r win-x64 -c Release /p:PublishSingleFile=true --self-contained true
+
+    - name: Upload exe
+      uses: actions/upload-artifact@v2
+      with:
+        name: WindowMaximizer
+        path: ./bin/Release/net8.0-windows/win-x64/WindowMaximizer.exe
+
+  release:
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - name: Download exe
+      uses: actions/download-artifact@v2
+      with:
+        name: WindowMaximizer
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ./WindowMaximizer.exe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# WindowMaximizer
+
+## Functionality
+
+WindowMaximizer is a utility that allows you to maximize the currently active window to a specified monitor. If the window is already maximized, it will restore the window to its previous size and position. This is useful for users who work with multiple monitors and want to quickly move and maximize windows across different screens.
+
+## How to Build Locally
+
+To build the project locally, you can use the following command:
+
+```sh
+dotnet publish -r win-x64 -c Release /p:PublishSingleFile=true --self-contained true
+```
+
+This command will create a self-contained executable file in the `.\bin\Release\net8.0-windows\win-x64\` directory.
+
+## GitHub Actions Workflow
+
+This repository includes a GitHub Actions workflow that automatically builds and releases the executable file on each push to the main branch. The workflow is defined in the `.github/workflows/build-and-release.yml` file.
+
+## Shortcut Hotkeys
+
+To handle the shortcut hotkeys, it is recommended to use a tool like Clavier+. You can download Clavier+ from the following link: [Clavier+](https://gryder.org/software/clavier-plus/)


### PR DESCRIPTION
Add README and GitHub Actions workflow for building and releasing executable.

* **README.md**
  - Explain the functionality of WindowMaximizer.
  - Provide instructions on how to build the project locally.
  - Mention the GitHub Actions workflow for building and releasing the executable.
  - Recommend using a tool like Clavier+ for handling shortcut hotkeys, with a link to Clavier+.

* **.github/workflows/build-and-release.yml**
  - Define a GitHub Actions workflow to trigger on push to the main branch.
  - Set up the build environment with the necessary dependencies.
  - Run the `dotnet publish` command to build the executable.
  - Upload the executable as an artifact.
  - Create a release and attach the executable artifact.

